### PR TITLE
add default $t version

### DIFF
--- a/nebula-polyglot-behavior.html
+++ b/nebula-polyglot-behavior.html
@@ -40,7 +40,8 @@
             notify: true
           },
           $t: {
-            type: Function
+            type: Function,
+            value: function() {return key => key}
           }
         }
       }


### PR DESCRIPTION
I want to have the keys displayed when i use an element in a demo page (without carying about lang and resources) or when i forgot to add the `resources` and `lang` property.

Changes made:
 - add default value for the function to return the key

@FabianWilms please review idea